### PR TITLE
fix(*): report test results only once in mocha 5

### DIFF
--- a/src/json-stream.js
+++ b/src/json-stream.js
@@ -28,7 +28,7 @@ function AnnotatedList(runner) {
     console.log(JSON.stringify([ 'fail', result ]));
   });
 
-  runner.on('end', () => {
+  runner.once('end', () => {
     process.stdout.write(JSON.stringify([ 'end', this.stats ]));
   });
 }

--- a/src/json.js
+++ b/src/json.js
@@ -34,7 +34,7 @@ function AnnotatedJSONReporter(runner) {
     this.pending.push(test);
   });
 
-  runner.on('end', () => {
+  runner.once('end', () => {
     const obj = {
       stats: this.stats,
       tests: this.tests.map(clean),

--- a/src/spec.js
+++ b/src/spec.js
@@ -62,7 +62,7 @@ function AnnotatedSpec(runner) {
     );
   });
 
-  runner.on('end', () => {
+  runner.once('end', () => {
     let fmt;
 
     // passes


### PR DESCRIPTION
Using `mocha@5`, each reporter writes two test reports to stdout at the end of every run. Each of the reporters in the mocha suite required similar changes to the ones included in this PR.

Relevant commit from mochajs/mocha: https://github.com/mochajs/mocha/commit/2c720a35000da0fecf11ef65c20ca4292c226ad7

This still needs some testing, but putting it up for review.